### PR TITLE
add wildcard locale support to lang() and locale() methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - added `unstyled-button()` method to remove default styling from a `<button>` element
 - added `prefixed-tag()` method for consistency when generating tag names
 - added Chinese font stacks
+- added wildcard support to `locale()` function (e.g. `locale(en_ ja_JP _DE)`)
 
 ### Resolved Issues:
 

--- a/lib/archetype/sass_extensions/functions/locale.rb
+++ b/lib/archetype/sass_extensions/functions/locale.rb
@@ -3,17 +3,36 @@
 #
 module Archetype::SassExtensions::Locale
   #
-  # get the current locale specified in config
+  # get the current locale specified in config or test a list of locales against the current locale
   #
+  # *Parameters*:
+  # - <tt>$locales</tt> {List} the list of locales to test
   # *Returns*:
-  # - {String} the current locale
+  # - {String|Boolean} the current locale or whether or not the current locale is in the test set
   #
-  def locale
-    return Sass::Script::String.new(Compass.configuration.locale || 'en_US')
+  def locale(locales = nil)
+    locale = (Compass.configuration.locale || 'en_US').to_s
+    # if the locales are nil, just return the current locale
+    return Sass::Script::String.new(locale) if locales.nil?
+    locales = locales.to_a.collect{|i| i.to_s}
+    # add wild card support for language or territory
+    match = locale.match(LOCALE_PATTERN)
+    # language with wildcard territory
+    language = match[1] + '_'
+    # territory with wildcard language
+    territory = '_' + match[2]
+    # for each item, look it up in the alias list
+    locales.each do |key|
+      if a = locale_aliases[key]
+        locales.delete(key)
+        locales.concat(a)
+      end
+    end
+    return Sass::Script::Bool.new(locales.include?(locale) || locales.include?(language) || locales.include?(territory))
   end
 
   #
-  # test a list of locales against the current locale (supports an alias map)
+  # test a list of locales against the current locale (this is now just an alias for locales(), for back-compat)
   #
   # *Parameters*:
   # - <tt>$locales</tt> {List} the list of locales to test
@@ -21,16 +40,9 @@ module Archetype::SassExtensions::Locale
   # - {Boolean} is the current locale in the list or not
   #
   def lang(locales)
-    locales = locales.to_a.collect{|i| i.to_s}
-    locales.each do |key|
-      if a = locale_aliases[key]
-        locales.delete(key)
-        locales.concat(a)
-      end
-    end
-    return Sass::Script::Bool.new(locales.include?(locale.to_s))
+    return locale(locales)
   end
-  
+
   #
   # get the current reading direction
   #
@@ -43,6 +55,9 @@ module Archetype::SassExtensions::Locale
   end
 
 private
+
+  LOCALE_PATTERN = /([a-z]{2})[-_]?([a-z]{2}?)/i
+
   #
   # provides an alias mapping for locale names
   #
@@ -52,8 +67,9 @@ private
   # TODO - make this easily extensible
   def locale_aliases
     if @locale_aliases.nil?
-      a = {}
-      a['CJK'] = ['ja_JP', 'ko_KR', 'zh_TW', 'zh_CN']
+      a = {
+        'CJK' => ['ja_JP', 'ko_KR', 'zh_TW', 'zh_CN']
+      }
       @locale_aliases = a
     end
     return @locale_aliases

--- a/test/fixtures/stylesheets/archetype/expected/locale.css
+++ b/test/fixtures/stylesheets/archetype/expected/locale.css
@@ -1,0 +1,23 @@
+.en_US {
+  content: "en_US";
+}
+
+.en_wild {
+  content: "en_*";
+}
+
+.wild_US {
+  content: "*_US";
+}
+
+.one {
+  content: "one of de_DE fr_FR pt_ en_US";
+}
+
+.not {
+  content: "not one of ja_JP pt_BR _GB de_";
+}
+
+.lang {
+  content: "en_US";
+}

--- a/test/fixtures/stylesheets/archetype/source/locale.scss
+++ b/test/fixtures/stylesheets/archetype/source/locale.scss
@@ -1,0 +1,43 @@
+@import "archetype";
+
+// test for a simple locale
+.en_US {
+  @if(locale(en_US)) {
+    content: "en_US";
+  }
+}
+
+// test for a wildcard territory
+.en_wild {
+  @if(locale(en_)) {
+    content: "en_*";
+  }
+}
+
+// test for a wildcard language
+.wild_US {
+  @if(locale(_US)) {
+    content: "*_US";
+  }
+}
+
+// multiple locales, one valid
+.one {
+  @if(locale(de_DE fr_FR pt_ en_US)) {
+    content: "one of de_DE fr_FR pt_ en_US";
+  }
+}
+
+// multiple locales, none valid
+.not {
+  @if(not locale(ja_JP pt_BR _GB de_)) {
+    content: "not one of ja_JP pt_BR _GB de_";
+  }
+}
+
+// test that the lang() alias works
+.lang {
+  @if(lang(en_US)) {
+    content: "en_US";
+  }
+}


### PR DESCRIPTION
this allows the user to test for wildcard territories/languages.

e.g.

``` scss
@if(locale(en_)) {
   // matches: en_US, en_GB, en_AU, etc
}

@if(locale(zh_)) {
  // matches: zh_TW, zh_CN, etc
}

@if(locale(_FI)) {
  // matches: fi_FI, sv_FI, etc
}
```
