### PR TITLE
Use the Sass logger for warnings.

### DIFF
--- a/lib/archetype/functions/css.rb
+++ b/lib/archetype/functions/css.rb
@@ -253,7 +253,7 @@ module Archetype::Functions::CSS
     else
       value = CSS_PRIMITIVES[value]
     end
-    helpers.logger.record(:warning, "cannot find a default value for `#{key}`") if value.nil?
+    helpers.logger.warn("cannot find a default value for `#{key}`") if value.nil?
     return value
   end
 
@@ -1270,7 +1270,7 @@ private
   # - {Sass::Null}
   #
   def self.warn(msg)
-    helpers.logger.record(:warning, msg)
+    helpers.logger.warn msg
     return Sass::Script::Value::Null.new
   end
 

--- a/lib/archetype/functions/helpers.rb
+++ b/lib/archetype/functions/helpers.rb
@@ -15,7 +15,7 @@ module Archetype::Functions::Helpers
   # provides a convenience interface to the Compass::Logger
   #
   def self.logger
-    @logger ||= Compass::Logger.new
+    Sass.logger
   end
 
   #
@@ -73,9 +73,9 @@ module Archetype::Functions::Helpers
       if previous.nil? and not item[2].nil?
         msg = "you're likely missing a comma or parens in your data structure"
         begin
-          logger.record(:warning, "#{msg}: #{item}")
+          logger.warn("#{msg}: #{item}")
         rescue
-          logger.record(:warning, msg)
+          logger.warn(msg)
         end
       end
 
@@ -128,7 +128,7 @@ module Archetype::Functions::Helpers
       hsh[key] = self.array_to_meta(hsh[key])
     end
 
-    logger.record(:warning, "one of your data structures is ambiguous, please double check near `#{previous}`") unless (previous.nil? or previous.empty?)
+    logger.warn("one of your data structures is ambiguous, please double check near `#{previous}`") unless (previous.nil? or previous.empty?)
 
     return hsh
   end

--- a/lib/archetype/sass_extensions/functions/numbers.rb
+++ b/lib/archetype/sass_extensions/functions/numbers.rb
@@ -70,7 +70,7 @@ module Archetype::SassExtensions::Numbers
     # if we don't understand the unit...
     if RESOLUTIONS[from].nil? and not unitless
       # warn
-      helpers.logger.record(:warning, "don't know how to convert `#{number}` to a #{to}")
+      helpers.logger.warn("don't know how to convert `#{number}` to a #{to}")
       # and return zero
       return Sass::Script::Value::Number.new(0)
     end

--- a/lib/archetype/sass_extensions/functions/styleguide.rb
+++ b/lib/archetype/sass_extensions/functions/styleguide.rb
@@ -547,7 +547,7 @@ private
         styles = styles.rmerge(extracted)
       elsif not helpers.is_value(sentence, :nil)
         msg = modifiers.length > 0 ? "please specify one of: #{modifiers.sort.join(', ')}" : "there are no registered components"
-        helpers.logger.record(:warning, "[#{Archetype.name}:styleguide:missing_identifier] `#{helpers.to_str(sentence)}` does not contain an identifier. #{msg}")
+        helpers.logger.warn("[#{Archetype.name}:styleguide:missing_identifier] `#{helpers.to_str(sentence)}` does not contain an identifier. #{msg}")
       end
     end
 


### PR DESCRIPTION
Compass will override the Sass logger if it needs to, gems should use Sass APIs directly as much as possible.
