### PR TITLE
Add conditional for extra vertical-align in buttons.scss

### DIFF
--- a/stylesheets/archetype/styleguide/components/_buttons.scss
+++ b/stylesheets/archetype/styleguide/components/_buttons.scss
@@ -36,7 +36,7 @@ $a-blackhole: styleguide-add-component($STYLEGUIDE_BUTTONS_ID,  $STYLEGUIDE_BUTT
     white-space             nowrap,
     // alignment
     inline-block            true, // this will use the inline-block() mixin
-    vertical-align          middle,
+    vertical-align          if($legacy-support-for-ie, middle, nil), //prevent rendering vertical-align twice if legacy support is disabled
     // states
     (states, (
       (hover, (


### PR DESCRIPTION
Pre Sass3.2: the vertical-align property and value shouldn't be rendered twice if legacy IE is disabled (the inline-block mixin already does what's needed).
