### PR TITLE
some more fixes for Sass 3.4 support

### DIFF
--- a/extensions/archetype-theme/stylesheets/archetype/theme/_helpers.scss
+++ b/extensions/archetype-theme/stylesheets/archetype/theme/_helpers.scss
@@ -157,16 +157,14 @@
 // @param     $type {String} the type of the loading spinner e.g. [static|dynamic]
 // @param     $dim {String} the dimension to return [width|height]
 // @param     $context {Number} the index for the context type
+// @param     $divisor {Number} an optional value to divide the dimension by
 // @return    {Number} the width/height of the loading spinner
-@function _styleguideGetLoaderDimension($size: medium, $type: static, $dim: width, $context: 1) {
+@function _styleguideGetLoaderDimension($size: medium, $type: static, $dim: width, $context: 1, $divisor: 1) {
+  $context: if(is-null($context), 1, $context);
   $img: nth-cyclic(map-get(map-get($CONFIG_LOADERS, $size), $type), $context);
   $sprite-file: -archetype-sprite-file($CONFIG_SPRITE_LOADERS, $img);
-  @if $dim == width {
-    @return -archetype-image-width($sprite-file);
-  }
-  @else {
-    @return -archetype-image-height($sprite-file);
-  }
+  $dim: if($dim == width, -archetype-image-width($sprite-file), -archetype-image-height($sprite-file));
+  @return if(is-null($dim), $dim, $dim / ($divisor * units($dim)));
 }
 
 // helper function to get the animation routine of the loading spinner
@@ -199,11 +197,14 @@
 // @return    {String} the CSS expression styles
 @function _styleguideGetLoaderExpression($size: medium, $context: 1) {
   $img: nth-cyclic(map-get(map-get($CONFIG_LOADERS, $size), static), $context);
-  $bg: -archetype-sprite($CONFIG_SPRITE_LOADERS, $img) no-repeat;
-  $bg: if(is-null($bg), none, $bg);
-  $width: _styleguideGetLoaderDimension($size, static, width, $context);
-  $height: _styleguideGetLoaderDimension($size, static, height, $context);
-  $margin-top: $height / -2;
-  $margin-left: $width / -2;
-  @return ("position:absolute;top:50%;left:50%;background:#{$bg};width:#{$width};height:#{$height};margin-left:#{$margin-left};margin-top:#{$margin-top};", false, loader);
+  $bg: -archetype-sprite($CONFIG_SPRITE_LOADERS, $img);
+  @if is-null($bg) {
+    $bg: $bg no-repeat;
+    $width: _styleguideGetLoaderDimension($size, static, width, $context) or 0;
+    $height: _styleguideGetLoaderDimension($size, static, height, $context) or 0;
+    $margin-top: $height or / -2;
+    $margin-left: $width / -2;
+    @return ("position:absolute;top:50%;left:50%;background:#{$bg};width:#{$width};height:#{$height};margin-left:#{$margin-left};margin-top:#{$margin-top};", false, loader);
+  }
+  @return "";
 }

--- a/extensions/archetype-theme/stylesheets/archetype/theme/components/_loaders.scss
+++ b/extensions/archetype-theme/stylesheets/archetype/theme/components/_loaders.scss
@@ -26,8 +26,8 @@ $a-blackhole: styleguide-add-component($STYLEGUIDE_LOADERS_ID, $STYLEGUIDE_LOADE
         background-position:    _styleguideGetLoaderPosition(medium, static),
         width:                  _styleguideGetLoaderDimension(medium, static, width),
         height:                 _styleguideGetLoaderDimension(medium, static, height),
-        margin-top:             _styleguideGetLoaderDimension(medium, static, height) / -2,
-        margin-left:            _styleguideGetLoaderDimension(medium, static, width) / -2,
+        margin-top:             _styleguideGetLoaderDimension(medium, static, height, null, -2),
+        margin-left:            _styleguideGetLoaderDimension(medium, static, width, null, -2),
         animation:              _styleguideGetLoaderAnimation(medium)
       )
     )
@@ -40,8 +40,8 @@ $a-blackhole: styleguide-add-component($STYLEGUIDE_LOADERS_ID, $STYLEGUIDE_LOADE
         background-position:    _styleguideGetLoaderPosition(large, static),
         width:                  _styleguideGetLoaderDimension(large, static, width),
         height:                 _styleguideGetLoaderDimension(large, static, height),
-        margin-top:             _styleguideGetLoaderDimension(large, static, height) / -2,
-        margin-left:            _styleguideGetLoaderDimension(large, static, width) / -2,
+        margin-top:             _styleguideGetLoaderDimension(large, static, height, null, -2),
+        margin-left:            _styleguideGetLoaderDimension(large, static, width, null, -2),
         animation:              _styleguideGetLoaderAnimation(large)
       )
     )
@@ -54,8 +54,8 @@ $a-blackhole: styleguide-add-component($STYLEGUIDE_LOADERS_ID, $STYLEGUIDE_LOADE
         background-position:    _styleguideGetLoaderPosition(small, static),
         width:                  _styleguideGetLoaderDimension(small, static, width),
         height:                 _styleguideGetLoaderDimension(small, static, height),
-        margin-top:             _styleguideGetLoaderDimension(small, static, height) / -2,
-        margin-left:            _styleguideGetLoaderDimension(small, static, width) / -2,
+        margin-top:             _styleguideGetLoaderDimension(small, static, height, null, -2),
+        margin-left:            _styleguideGetLoaderDimension(small, static, width, null, -2),
         animation:              _styleguideGetLoaderAnimation(small)
       )
     )
@@ -69,8 +69,8 @@ $a-blackhole: styleguide-add-component($STYLEGUIDE_LOADERS_ID, $STYLEGUIDE_LOADE
         background-position:    _styleguideGetLoaderPosition(medium, static, 2),
         width:                  _styleguideGetLoaderDimension(medium, static, width, 2),
         height:                 _styleguideGetLoaderDimension(medium, static, height, 2),
-        margin-top:             _styleguideGetLoaderDimension(medium, static, height, 2) / -2,
-        margin-left:            _styleguideGetLoaderDimension(medium, static, width, 2) / -2,
+        margin-top:             _styleguideGetLoaderDimension(medium, static, height, 2, -2),
+        margin-left:            _styleguideGetLoaderDimension(medium, static, width, 2, -2),
         animation:              _styleguideGetLoaderAnimation(medium, 2)
       )
     )
@@ -82,8 +82,8 @@ $a-blackhole: styleguide-add-component($STYLEGUIDE_LOADERS_ID, $STYLEGUIDE_LOADE
         background-position:    _styleguideGetLoaderPosition(large, static, 2),
         width:                  _styleguideGetLoaderDimension(large, static, width, 2),
         height:                 _styleguideGetLoaderDimension(large, static, height, 2),
-        margin-top:             _styleguideGetLoaderDimension(large, static, height, 2) / -2,
-        margin-left:            _styleguideGetLoaderDimension(large, static, width, 2) / -2,
+        margin-top:             _styleguideGetLoaderDimension(large, static, height, 2, -2),
+        margin-left:            _styleguideGetLoaderDimension(large, static, width, 2, -2),
         animation:              _styleguideGetLoaderAnimation(large, 2)
       )
     )
@@ -95,8 +95,8 @@ $a-blackhole: styleguide-add-component($STYLEGUIDE_LOADERS_ID, $STYLEGUIDE_LOADE
         background-position:    _styleguideGetLoaderPosition(small, static, 2),
         width:                  _styleguideGetLoaderDimension(small, static, width, 2),
         height:                 _styleguideGetLoaderDimension(small, static, height, 2),
-        margin-top:             _styleguideGetLoaderDimension(small, static, height, 2) / -2,
-        margin-left:            _styleguideGetLoaderDimension(small, static, width, 2) / -2,
+        margin-top:             _styleguideGetLoaderDimension(small, static, height, 2, -2),
+        margin-left:            _styleguideGetLoaderDimension(small, static, width, 2, -2),
         animation:              _styleguideGetLoaderAnimation(small, 2)
       )
     )

--- a/lib/archetype/sass_extensions/functions/environment.rb
+++ b/lib/archetype/sass_extensions/functions/environment.rb
@@ -22,7 +22,7 @@ module Archetype::SassExtensions::Environment
   #
   def archetype_namespace(string)
     namespace = environment.var('CONFIG_NAMESPACE')
-    return string if is_null(namespace).value
+    return string if helpers.is_null(namespace)
     return identifier(namespace.value + '_' + string.value)
   end
 

--- a/lib/archetype/sass_extensions/functions/lists.rb
+++ b/lib/archetype/sass_extensions/functions/lists.rb
@@ -15,7 +15,7 @@ module Archetype::SassExtensions::Lists
   #
   def list_replace(list, idx = false, value = nil, separator = nil)
     # return early if the index is invalid (no operation)
-    return list if (!idx || is_null(idx).value || idx.value == false)
+    return list if (!idx || helpers.is_null(idx) || idx.value == false)
     separator ||= list.separator if list.is_a?(Sass::Script::Value::List)
     # cast and zero-index $idx
     idx = (idx.value) - 1
@@ -188,6 +188,7 @@ module Archetype::SassExtensions::Lists
   # - {*} the nth item in the List
   #
   def nth_cyclic(list, n = 1)
+    n = 1 if helpers.is_null(n)
     n = n.to_i if n.is_a?(Sass::Script::Value::Number)
     list = list.to_a
     return list[(n - 1) % list.size]

--- a/lib/archetype/sass_extensions/functions/styleguide.rb
+++ b/lib/archetype/sass_extensions/functions/styleguide.rb
@@ -22,8 +22,8 @@ module Archetype::SassExtensions::Styleguide
   #
   def _styleguide(description, state = nil, theme = nil)
     extras = []
-    extras << "state: #{state}" unless (state.nil? or is_null(state))
-    extras << "theme: #{theme}" unless (theme.nil? or is_null(theme))
+    extras << "state: #{state}" unless (state.nil? or helpers.is_null(state))
+    extras << "theme: #{theme}" unless (theme.nil? or helpers.is_null(theme))
     extras = extras.join(', ')
     msg = "`#{description}`"
     msg << " (#{extras})" unless extras.empty?

--- a/lib/archetype/sass_extensions/functions/ui/glyphs.rb
+++ b/lib/archetype/sass_extensions/functions/ui/glyphs.rb
@@ -75,7 +75,7 @@ module Archetype::SassExtensions::UI::Glyphs
   def register_glyph_library(key, library)
     registry = archetype_glyphs_registry
     # if it's already in the registry, just return the current list
-    if is_null(registry[key])
+    if helpers.is_null(registry[key])
       registry = registry.dup
       registry[key] = library
       registry = Sass::Script::Value::Map.new(registry)

--- a/lib/archetype/sass_extensions/functions/ui/scopes.rb
+++ b/lib/archetype/sass_extensions/functions/ui/scopes.rb
@@ -14,7 +14,7 @@ module Archetype::SassExtensions::UI::Scopes
     # we need a dup as the Hash is frozen
     breakpoints = registered_breakpoints.dup
     force = force.nil? ? false : force.value
-    not_registered = breakpoints[key].nil? || is_null(breakpoints[key]).value
+    not_registered = breakpoints[key].nil? || helpers.is_null(breakpoints[key])
     # if there's no key registered...
     if force || not_registered
       # just register the value
@@ -61,9 +61,9 @@ module Archetype::SassExtensions::UI::Scopes
     modifier_separator = environment.var('CONFIG_BEM_MODIFIER_SEPARATOR')
     modifier_separator = modifier_separator.nil? ? '--' : modifier_separator.value
 
-    context  = is_null(context).value  ? ''  : context.value
-    element  = is_null(element).value  ? nil : element.value
-    modifier = is_null(modifier).value ? nil : modifier.value
+    context  = helpers.is_null(context) ? ''  : context.value
+    element  = helpers.is_null(element) ? nil : element.value
+    modifier = helpers.is_null(modifier) ? nil : modifier.value
 
     selector = context
 

--- a/lib/archetype/sass_extensions/functions/util/debug.rb
+++ b/lib/archetype/sass_extensions/functions/util/debug.rb
@@ -13,7 +13,7 @@ module Archetype::SassExtensions::Util::Debug
     return bool(false) unless (environment.var('CONFIG_DEBUG_ENVS') || []).to_a.include?(archetype_env)
     # then check if the debug flag/override is truthy
     # if the param is non-null, then use it
-    return iff unless is_null(iff).value
+    return iff unless helpers.is_null(iff)
     # otherwise, use `CONFIG_DEBUG`
     return environment.var('CONFIG_DEBUG') || bool(false)
   end

--- a/lib/archetype/sass_extensions/functions/util/images.rb
+++ b/lib/archetype/sass_extensions/functions/util/images.rb
@@ -24,8 +24,7 @@ module Archetype::SassExtensions::Util::Images
   # - {Boolean} is the sprite set
   #
   def _archetype_check_sprite(map)
-    status = !(global_sprites_disabled? && (is_null(map) || !map.value))
-    return bool(status)
+    return bool(_is_sprite_valid(map))
   end
   Sass::Script::Functions.declare :_archetype_check_sprite, [:map]
 
@@ -41,7 +40,7 @@ module Archetype::SassExtensions::Util::Images
   # - {Sprite} the sprite object or `null`
   #
   def _archetype_sprite(map, sprite, offset_x = number(0), offset_y = number(0))
-    return null unless _archetype_check_sprite(map)
+    return null unless _is_sprite_valid(map)
     return sprite(map, sprite, offset_x, offset_y)
   end
   Sass::Script::Functions.declare :_archetype_sprite, [:map, :sprite, :offset_x, :offset_y]
@@ -58,7 +57,7 @@ module Archetype::SassExtensions::Util::Images
   # - {List} the sprite position or `null`
   #
   def _archetype_sprite_position(map, sprite, offset_x = number(0), offset_y = number(0))
-    return null unless _archetype_check_sprite(map)
+    return null unless _is_sprite_valid(map)
     return sprite_position(map, sprite, offset_x, offset_y)
   end
   Sass::Script::Functions.declare :_archetype_sprite_position, [:map, :sprite, :offset_x, :offset_y]
@@ -72,7 +71,7 @@ module Archetype::SassExtensions::Util::Images
   # - {String} the sprite URL or `null`
   #
   def _archetype_sprite_url(map)
-    return null unless _archetype_check_sprite(map)
+    return null unless _is_sprite_valid(map)
     return sprite_url(map)
   end
   Sass::Script::Functions.declare :_archetype_sprite_url, [:map]
@@ -87,7 +86,7 @@ module Archetype::SassExtensions::Util::Images
   # - {ImageFile} the image or `null`
   #
   def _archetype_sprite_file(map, sprite)
-    return null unless _archetype_check_sprite(map)
+    return null unless _is_sprite_valid(map)
     return sprite_file(map, sprite)
   end
   Sass::Script::Functions.declare :_archetype_sprite_file, [:map, :sprite]
@@ -102,7 +101,7 @@ module Archetype::SassExtensions::Util::Images
   # - {Number} the width of the image or `null`
   #
   def _archetype_image_width(image)
-    return null if is_null(image).value
+    return null if helpers.is_null(image)
     return image_width(image)
   end
   Sass::Script::Functions.declare :_archetype_image_width, [:image]
@@ -117,12 +116,16 @@ module Archetype::SassExtensions::Util::Images
   # - {Number} the height of the image or `null`
   #
   def _archetype_image_height(image)
-    return null if is_null(image).value
+    return null if helpers.is_null(image)
     return image_height(image)
   end
   Sass::Script::Functions.declare :_archetype_image_height, [:image]
 
 private
+
+  def _is_sprite_valid(map)
+    return !global_sprites_disabled? && !(helpers.is_null(map) || !map.value)
+  end
 
   def global_sprites_disabled?
     sprites_disabled = environment.var('CONFIG_DISABLE_STYLEGUIDE_SPRITES')

--- a/lib/archetype/sass_extensions/functions/util/spacing.rb
+++ b/lib/archetype/sass_extensions/functions/util/spacing.rb
@@ -35,7 +35,7 @@ module Archetype::SassExtensions::Util::Spacing
   # - {Number} the calculated spacing
   #
   def _spacing(unit = null, direction = identifier(horizontal), abuse = bool(false))
-    return null if is_null(unit).value
+    return null if helpers.is_null(unit)
     unit = _archetype_integerize(unit, abuse)
     direction = helpers.to_str(direction) == 'vertical' ? 'VERTICAL' : 'HORIZONTAL'
     config = "CONFIG_#{direction}_SPACING"


### PR DESCRIPTION
sass 3.4 doesn't play nicely when performing operations on `null` values, so we have to add some additional logic to handle those before performing those operations
