### PR TITLE
allow non-multiplier values in spacing methods per #104

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - added `archetype-bundled` extension which is a "kitchen sink" bundle of Archetype core and all official extensions
 - added `styleguide_allow_missing` compiler option to force errors on missing styleguide identifiers
 
+### Resolved Issues:
+
+- allow non-multiplier values in `*-spacing` methods
+
 ## 1.0.0.alpha.4
 
 ### Resolved Issues:

--- a/lib/archetype/sass_extensions/functions/locale.rb
+++ b/lib/archetype/sass_extensions/functions/locale.rb
@@ -25,7 +25,6 @@ module Archetype::SassExtensions::Locale
       end
     end
     return Sass::Script::Bool.new(
-      locales.include?(locale) ||
       locales.include?("#{locale[:language]}_#{locale[:territory]}") ||
       locales.include?(locale[:language] + '_') ||
       locales.include?('_' + locale[:territory])

--- a/lib/archetype/sass_extensions/functions/util/spacing.rb
+++ b/lib/archetype/sass_extensions/functions/util/spacing.rb
@@ -36,6 +36,9 @@ module Archetype::SassExtensions::Util::Spacing
   #
   def _spacing(unit = null, direction = identifier(horizontal), abuse = bool(false))
     return null if helpers.is_null(unit)
+
+    return unit unless (unit.is_a?(Sass::Script::Value::Number) && unitless(unit).to_bool)
+
     unit = _archetype_integerize(unit, abuse)
     direction = helpers.to_str(direction) == 'vertical' ? 'VERTICAL' : 'HORIZONTAL'
     config = "CONFIG_#{direction}_SPACING"

--- a/test/fixtures/stylesheets/archetype/expected/utilities/spacing/horizontal-spacing.css
+++ b/test/fixtures/stylesheets/archetype/expected/utilities/spacing/horizontal-spacing.css
@@ -27,3 +27,10 @@ e {
   margin-left: 0px;
   margin-right: 0px;
 }
+
+f {
+  padding-left: auto;
+  padding-right: 25px;
+  padding-left: 15px;
+  padding-right: 5px;
+}

--- a/test/fixtures/stylesheets/archetype/source/utilities/spacing/horizontal-spacing.scss
+++ b/test/fixtures/stylesheets/archetype/source/utilities/spacing/horizontal-spacing.scss
@@ -25,3 +25,8 @@ e {
   @include horizontal-spacing($left: 0, $right: 0);
   @include horizontal-spacing($left: 0, $right: 0, $method: margin);
 }
+
+f {
+  @include horizontal-spacing(auto 5);
+  @include horizontal-spacing(3 5px);
+}


### PR DESCRIPTION
this will allow the spacing methods to be more flexible:
```scss
@include horizontal-spacing(auto 5); // `auto` is left alone, `5` is multiplied
@include horizontal-spacing(3 5px); //  `3` is multiplied, `5px` is left alone
```