### PR TITLE
replaced multiple if-conditions with 1 case-block

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
+before_install:
+  - gem update bundler
 before_script:
   - ulimit -S -s unlimited
   - ulimit -a

--- a/lib/archetype/sass_extensions/functions/numbers.rb
+++ b/lib/archetype/sass_extensions/functions/numbers.rb
@@ -18,9 +18,15 @@ module Archetype::SassExtensions::Numbers
   # - {Number} the number without units
   #
   def strip_units(number)
-    value = 0
-    value = number.value.to_f if number.is_a?(Sass::Script::Value::String)
-    value = number.value if number.is_a?(Sass::Script::Value::Number)
+    case number
+    when Sass::Script::Value::String
+      value = number.value.to_f
+    when Sass::Script::Value::Number
+      value = number.value
+    else
+      value = 0
+    end
+
     return number(value)
   end
 


### PR DESCRIPTION
A method was using multiple single-line if-conditions to assign a value to a variable. This PR replaces that with the more readable case-statements.

Since the tests were failing for the `master` branch, I have based this work on another [this](https://github.com/linkedin/archetype/pull/108) PR.
