### PR TITLE
travis: update bundler before installing gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
+before_install:
+  - gem update bundler
 before_script:
   - ulimit -S -s unlimited
   - ulimit -a


### PR DESCRIPTION
Travis builds are currently failing. This PR is to resolve this issue and ease contributions by updating the bundler gem before installing other gems.
